### PR TITLE
#1266 resolving through tables defined as strings on m2m relations

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -144,6 +144,7 @@ Authors
 - `DanialErfanian <https://github.com/DanialErfanian>`_
 - `Sridhar Marella <https://github.com/sridhar562345>`_
 - `Mattia Fantoni <https://github.com/MattFanto>`_
+- `Trent Holliday <https://github.com/trumpet2012>`_
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,10 @@ Changes
 
 Unreleased
 ----------
-
 - Made ``skip_history_when_saving`` work when creating an object - not just when
   updating an object (gh-1262)
 - Improved performance of the ``latest_of_each()`` history manager method (gh-1360)
+- Added support for m2m fields that specify through tables as strings (gh-1390)
 
 3.7.0 (2024-05-29)
 ------------------

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -237,6 +237,18 @@ class PollWithSelfManyToMany(models.Model):
     history = HistoricalRecords(m2m_fields=[relations])
 
 
+class PollWithManyToManyThroughString(models.Model):
+    books = models.ManyToManyField("Book", through="PollBookThroughTable")
+    history = HistoricalRecords(m2m_fields=[books])
+
+
+class PollBookThroughTable(models.Model):
+    book = models.ForeignKey("Book", on_delete=models.CASCADE)
+    poll = models.ForeignKey(
+        "PollWithManyToManyThroughString", on_delete=models.CASCADE
+    )
+
+
 class CustomAttrNameForeignKey(models.ForeignKey):
     def __init__(self, *args, **kwargs):
         self.attr_name = kwargs.pop("attr_name", None)


### PR DESCRIPTION
Supporting through table relations being provided as strings on m2m fields.